### PR TITLE
fix: point PROXY_URL directly at AWS HTTP Gateway

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -6,8 +6,6 @@ export default {
 			return new Response('Bad request: Missing `PROXY_URL` environment variable', { status: 400 });
 		}
 
-		let res = await fetch(proxyUrl, request);
-
-		return res;
+		return await fetch(proxyUrl, request);
 	},
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,10 +12,10 @@ routes = [
 ]
 
 [env.staging.vars]
-PROXY_URL = "https://staging.up.web3.storage"
+PROXY_URL = "https://wqlmdr24gf.execute-api.us-east-2.amazonaws.com"
 
 [env.production]
 account_id = "fffa4b4363a7e5250af8357087263b3a"
 
 [env.production.vars]
-PROXY_URL = "https://up.web3.storage"
+PROXY_URL = "	https://riu5w2lla3.execute-api.us-west-2.amazonaws.com"


### PR DESCRIPTION
pointing it at a web3.storage URL sent it back through the Cloudflare proxy maze, where it got lost